### PR TITLE
Division by zero in a virtual method

### DIFF
--- a/false-negative/virtual-div-by-zero.cpp
+++ b/false-negative/virtual-div-by-zero.cpp
@@ -13,6 +13,9 @@ public:
     explicit X(int v) : value(v) {}
 
     int test(int a) override {
+        // Division by zero is in the line below.
+        // If we rewrite the expression as "10 / a" and pass 0 to the method,
+        // Clang-Tidy will report the error.
         return 10 / (value - a);
     }
 };

--- a/false-negative/virtual-div-by-zero.cpp
+++ b/false-negative/virtual-div-by-zero.cpp
@@ -1,0 +1,26 @@
+// Clang-Tidy cannot find DIVISION BY ZERO in a virtual method.
+
+#include <iostream>
+
+struct Intf {
+    virtual int test(int a) = 0;
+};
+
+class X : public Intf {
+private:
+    int value;
+public:
+    explicit X(int v) : value(v) {}
+
+    int test(int a) override {
+        return 10 / (value - a);
+    }
+};
+
+int main() {
+    X arr[] = {X{0}, X(5), X{10}};
+    for (X& x : arr) {
+        std::cout << x.test(5) << std::endl;
+    }
+    return 0;
+}

--- a/false-negative/virtual-div-by-zero.cpp
+++ b/false-negative/virtual-div-by-zero.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 struct Intf {
+    // Note: virtual method is required. Otherwise, Clang-Tidy finds the error.
     virtual int test(int a) = 0;
 };
 

--- a/false-negative/virtual-div-by-zero.cpp
+++ b/false-negative/virtual-div-by-zero.cpp
@@ -18,9 +18,7 @@ public:
 };
 
 int main() {
-    X arr[] = {X{0}, X(5), X{10}};
-    for (X& x : arr) {
-        std::cout << x.test(5) << std::endl;
-    }
+    X x{5};
+    std::cout << x.test(5) << std::endl;
     return 0;
 }


### PR DESCRIPTION
Examples that demonstrates that Clang-Tidy cannot find DIVISION BY ZERO in a virtual method.