### PR TITLE
Infinite recursion example

### DIFF
--- a/false-negative/infinite-recursion.cpp
+++ b/false-negative/infinite-recursion.cpp
@@ -1,10 +1,10 @@
-// Clang-Tidy cannot detect infinite recursion.
+// Clang-Tidy cannot detect infinite recursion even for trivial cases.
 
 #include <iostream>
 
 // This function contains infinite recursion.
 int recursion(int x) {
-    return recursion(x + 1) + recursion(x - 1);
+    return recursion(x + 1);
 }
 int main() {
     std::cout << recursion(10) << std::endl;

--- a/false-negative/infinite-recursion.cpp
+++ b/false-negative/infinite-recursion.cpp
@@ -1,0 +1,12 @@
+// Clang-Tidy cannot detect infinite recursion.
+
+#include <iostream>
+
+// This function contains infinite recursion.
+int recursion(int x) {
+    return recursion(x + 1) + recursion(x - 1);
+}
+int main() {
+    std::cout << recursion(10) << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Example demonstrating that Clang-Tidy is unable to detect infinite recursion bugs.