### PR TITLE
Deleting duplicated pointers stored in a container.

### DIFF
--- a/false-negative/duplicated-delete.cpp
+++ b/false-negative/duplicated-delete.cpp
@@ -1,0 +1,18 @@
+// Clang-Tidy fails to detect deleting duplicated pointers
+// stored in a container class.
+
+#include <array>
+
+int main() {
+    // Two pointers.
+    int* p1 = new int{5};
+    int* p2 = new int{10};
+    // Array contains duplicated pointers.
+    // For old-style C array "int* []" Clang-Tidy detects issues.
+    std::array<int *, 4> ptrs = {p1, p2, p1, p2};
+    for (int i = 0; i < 4; ++i) {
+        // Bug: Attempt to free released memory
+        delete ptrs[i];
+    }
+    return 0;
+}


### PR DESCRIPTION
Bug: A container stores pointers. When container is not needed any longer, its elements are deleted.

If elements are duplicated, a memory error occurs.

Signed-off-by: andrewt0301 <andrewt0301@gmail.com>