### PR TITLE
Buffer overrun example

### DIFF
--- a/false-negative/buffer-overrun.cpp
+++ b/false-negative/buffer-overrun.cpp
@@ -1,0 +1,26 @@
+// Clang-Tidy fails to detect writing beyond the scope of an array.
+
+// Returns incorrectly calculated in some cases array index.
+int find_index(const int* arr, const int count, const int val) {
+    int index;
+    for (index = 0; index < count; ++index) {
+        if (arr[index] == val) {
+            break;
+        }
+    }
+    // Returns an index beyond array borders.
+    return index;
+}
+
+// This needs to be in a separate function (to get the symptoms of stack corruption).
+void test() {
+    int arr[] = {1, 2, 5, 6};
+    // Buffer overrun is here: arr[N] is assigned corrupting the stack.
+    // Array index depends on function return value.
+    arr[find_index(arr, 4, 3)] = 10;
+}
+
+int main() {
+    test();
+    return 0;
+}

--- a/false-negative/data-execution.cpp
+++ b/false-negative/data-execution.cpp
@@ -1,0 +1,20 @@
+// Clang-Tidy fails to detect data execution causing a crash.
+
+struct Function {
+    unsigned int data;
+
+    Function() : data(0xDEADBEEF) {}
+
+    void operator()() {
+        // Data are cast to a function.
+        auto func = reinterpret_cast<void (*)()>(this);
+        // Data execution causes crash.
+        func();
+    }
+};
+
+int main() {
+    Function func;
+    func();
+    return 0;
+}


### PR DESCRIPTION
Stack corruption by buffer overrun.

Signed-off-by: andrewt0301 <andrewt0301@gmail.com>